### PR TITLE
Impressão do contador na zerézima

### DIFF
--- a/URNA.ALG
+++ b/URNA.ALG
@@ -54,9 +54,9 @@ Inicio
    limpatela
    //Exibe o numero e o nome dos candidatos
    escreval("============ZERÉZIMA============")
-   escreval(numeroCandidato1, " - ", nomeCandidato1, ":")
-   escreval(numeroCandidato2, " - ", nomeCandidato2, ":")
-   escreval(numeroCandidato3, " - ", nomeCandidato3, ":")
+   escreval(numeroCandidato1, " - ", nomeCandidato1, ":", contCandidato1)
+   escreval(numeroCandidato2, " - ", nomeCandidato2, ":", contCandidato2)
+   escreval(numeroCandidato3, " - ", nomeCandidato3, ":", contCandidato3)
    escreval("0-Branco", contBranco)
    escreval("-1 - Votos Nulos", contNulo)
    escreval("")


### PR DESCRIPTION
Ao imprimir a zerézima não estava mostrando a quantidade de votos, foi implementada então a inserção deste contador no relatório.